### PR TITLE
Allow authenticating via query string parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ beginning with that prefix up to the `/`. For example a token valid for
 Query parameters (e.g, ``/foo?query-param`) and hostnames do not contribute to
 the MAC, only the path part of the URI.
 
+If your websockets client does not support HTTP authentication, you can pass the
+token as a parameter named "auth":
+
+```
+https://hookbot.scraperwiki.com/pub/foo/bar?auth=2e1150434ba1d8c33bce7c82ee08b5d9850342c7
+```
+
 Wider scope for publication keys
 --------------------------------
 

--- a/pkg/hookbot/auth.go
+++ b/pkg/hookbot/auth.go
@@ -43,26 +43,31 @@ func (h *Hookbot) IsKeyOK(w http.ResponseWriter, r *http.Request) bool {
 	authorization := r.Header.Get("Authorization")
 	fields := strings.Fields(authorization)
 
-	if len(fields) != 2 {
-		return false
-	}
-
-	authType, givenKey := fields[0], fields[1]
-
 	var givenMac string
 
-	switch strings.ToLower(authType) {
-	default:
-		return false // Not understood
-	case "basic":
-		var ok bool
-		givenMac, _, ok = r.BasicAuth()
-		if !ok {
+	if len(fields) != 2 {
+		authParam := r.URL.Query()["auth"]
+		if len(authParam) != 1 {
 			return false
 		}
+		givenMac = authParam[0]
+	} else {
 
-	case "bearer":
-		givenMac = givenKey // No processing required
+		authType, givenKey := fields[0], fields[1]
+
+		switch strings.ToLower(authType) {
+		default:
+			return false // Not understood
+		case "basic":
+			var ok bool
+			givenMac, _, ok = r.BasicAuth()
+			if !ok {
+				return false
+			}
+
+		case "bearer":
+			givenMac = givenKey // No processing required
+		}
 	}
 
 	// Try all subpaths and see if any of them matches the given MAC.


### PR DESCRIPTION
Since the Webhook API in Chrome & Firefox does not allow HTTP authentication nor adding headers.

(Commit pulled over from https://github.com/jsalvata/hookbot/commit/acfb5f6e4fdd0f84e0a2b4758ee0b61da818c287#diff-64d24bd263cd63879b08b9ddc3d4fa62b9faf1aba59cd05142b79450b060b863R54 )